### PR TITLE
Add GenerateFullName class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add GenerateFullName class
+
 ## [v1.1.0] - 2019-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # simplesamlphp-module-fullnameparser
 
-A SimpleSAMLphp module for generating givenName and sn from displayName.
+A SimpleSAMLphp module for generating givenName, sn and displayName.
 This module is using the [PHP-Name-Parser](https://github.com/joshfraser/PHP-Name-Parser) library.
 
-## SimpleSAMLphp configuration
+## FullNameParsing
+
+Generates the user's given name and surname based on the available full name information.
+
+### SimpleSAMLphp configuration
 
 The following authproc filter configuration options are supported:
 
@@ -24,6 +28,31 @@ The following authproc filter configuration options are supported:
         ),
 ```
 
+## GenerateFullName
+
+Generates the user's full name based on the available given name and surname information.
+
+### SimpleSAMLphp configuration
+
+The following authproc filter configuration options are supported:
+
+* `fullNameAttribute`: Optional, a string to use as the name of the attribute that holds the user's full name. Defaults to 'displayName'.
+* `firstNameAttribute`: Optional, a string to use as the name of the attribute that will hold the user's first name. Defaults to 'givenName'.
+* `lastNameAttribute`: Optional, a string to use as the name of the attribute that will hold the user's last name. Defaults to 'sn'.
+
+### Example authproc filter configuration
+
+```php
+    authproc = array(
+        ...
+        30 => array(
+            'class' => 'fullnameparser:GenerateFullName',
+            'fullNameAttribute' => 'common_name', // Optional, defaults to 'displayName'
+            'firstNameAttribute' => 'first_name', // Optional, defaults to 'givenName'
+            'lastNameAttribute' => 'last_name',   // Optional, defaults to 'sn'
+        ),
+```
+
 ## Compatibility matrix
 
 This table matches the module version with the supported SimpleSAMLphp version.
@@ -36,3 +65,4 @@ This table matches the module version with the supported SimpleSAMLphp version.
 ## License
 
 Licensed under the Apache 2.0 license, for details see `LICENSE`.
+

--- a/lib/Auth/Process/GenerateFullName.php
+++ b/lib/Auth/Process/GenerateFullName.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Authentication processing filter to split full name to first name and last name.
+ * 
+ * Example configuration in the config/config.php
+ *
+ *    authproc.aa = array(
+ *       ...
+ *       '61' => array(
+ *            'class' => 'fullnameparser:GenerateFullName',
+ *            'fullNameAttribute' => 'common_name', // Optional, defaults to 'displayName'
+ *            'firstNameAttribute' => 'first_name', // Optional, defaults to 'givenName'
+ *            'lastNameAttribute' => 'last_name',   // Optional, defaults to 'sn'
+ *       ),
+ *
+ * @author nikosev<nikos.ev@hotmail.com>
+ * @package SimpleSAMLphp
+ */
+
+class sspmod_fullnameparser_Auth_Process_GenerateFullName extends SimpleSAML_Auth_ProcessingFilter
+{
+
+    private $fullNameAttribute = 'displayName';
+
+    private $firstNameAttribute = 'givenName';
+
+    private $lastNameAttribute = 'sn';
+
+    /**
+     * Initialize this filter, parse configuration
+     *
+     * @param array $config Configuration information about this filter.
+     * @param mixed $reserved For future use.
+     *
+     * @throws Exception If the configuration of the filter is wrong.
+     */
+    public function __construct($config, $reserved)
+    {
+        parent::__construct($config, $reserved);
+        assert('is_array($config)');
+
+
+        if (array_key_exists('fullNameAttribute', $config)) {
+            if (!is_string($config['fullNameAttribute'])) {
+                SimpleSAML_Logger::error("[GenerateFullName] Configuration error: 'fullNameAttribute' not a string literal");
+                throw new Exception(
+                    "GenerateFullName configuration error: 'fullNameAttribute' not a string literal");
+            }
+            $this->fullNameAttribute = $config['fullNameAttribute'];
+        }
+
+        if (array_key_exists('firstNameAttribute', $config)) {
+            if (!is_string($config['firstNameAttribute'])) {
+                SimpleSAML_Logger::error("[GenerateFullName] Configuration error: 'firstNameAttribute' not a string literal");
+                throw new Exception(
+                    "GenerateFullName configuration error: 'firstNameAttribute' not a string literal");
+            }
+            $this->firstNameAttribute = $config['firstNameAttribute'];
+        }
+
+        if (array_key_exists('lastNameAttribute', $config)) {
+            if (!is_string($config['lastNameAttribute'])) {
+                SimpleSAML_Logger::error("[GenerateFullName] Configuration error: 'lastNameAttribute' not a string literal");
+                throw new Exception(
+                    "GenerateFullName configuration error: 'lastNameAttribute' not a string literal");
+            }
+            $this->lastNameAttribute = $config['lastNameAttribute'];
+        }
+
+    }
+
+    /**
+     * Apply filter to rename attributes.
+     *
+     * @param array &$state The current state.
+     */
+    public function process(&$state)
+    {
+        assert(is_array($state));
+        assert(array_key_exists('Attributes', $state));
+
+        if (empty($state['Attributes'][$this->fullNameAttribute]) && !empty($state['Attributes'][$this->firstNameAttribute]) && !empty($state['Attributes'][$this->lastNameAttribute])) {
+            SimpleSAML_Logger::debug("[GenerateFullName] process: input: '" . $this->firstNameAttribute . "', value: '" . $state['Attributes'][$this->firstNameAttribute][0] . "'");
+            SimpleSAML_Logger::debug("[GenerateFullName] process: input: '" . $this->lastNameAttribute . "', value: '" . $state['Attributes'][$this->lastNameAttribute][0] . "'");
+            $state['Attributes'][$this->fullNameAttribute] = array($state['Attributes'][$this->firstNameAttribute][0] . " " . $state['Attributes'][$this->lastNameAttribute][0]);
+            SimpleSAML_Logger::debug("[GenerateFullName] process: output: '" . $this->fullNameAttribute . "', value: '" . $state['Attributes'][$this->fullNameAttribute][0] . "'");
+
+        }
+    }
+}
+


### PR DESCRIPTION


Create new authproc filter --> fullnameparser:GenerateFullName
Generates the user's full name based on the available given name and surname information.

The following authproc filter configuration options are supported:
- fullNameAttribute: Optional, a string to use as the name of the attribute that holds the user's full name. Defaults to 'displayName'.
- firstNameAttribute: Optional, a string to use as the name of the attribute that will hold the user's first name. Defaults to 'givenName'.
- lastNameAttribute: Optional, a string to use as the name of the attribute that will hold the user's last name. Defaults to 'sn'.